### PR TITLE
Debug sim buoy detection

### DIFF
--- a/sss_object_detection/scripts/sim_sss_detection_publisher.py
+++ b/sss_object_detection/scripts/sim_sss_detection_publisher.py
@@ -33,8 +33,8 @@ class sim_sss_detector:
         self.marked_positions = {}
 
         self.tf_listener = tf.TransformListener()
-        self.odom_sub = rospy.Subscriber('/{}/dr/odom'.format(robot_name), Odometry,
-                                         self._update_pose)
+        self.odom_sub = rospy.Subscriber('/{}/dr/odom'.format(robot_name),
+                                         Odometry, self._update_pose)
         self.marked_pos_sub = rospy.Subscriber(
             '/{}/sim/marked_positions'.format(robot_name), MarkerArray,
             self._update_marked_positions)
@@ -52,10 +52,10 @@ class sim_sss_detector:
         if len(self.marked_positions) > 0:
             return
         for marker in msg.markers:
-            self.marked_positions['{}/{}'.format(marker.ns, marker.id)] = marker
-        print(
-            'There are {} number of marked positions'.format(len(self.marked_positions))
-        )
+            self.marked_positions['{}/{}'.format(marker.ns,
+                                                 marker.id)] = marker
+        print('There are {} number of marked positions'.format(
+            len(self.marked_positions)))
 
     def _update_pose(self, msg):
         """Update prev_pose and current_pose according to the odom msg received"""
@@ -76,7 +76,8 @@ class sim_sss_detector:
             detectable = cos_sim <= self.buoy_radius
 
             if detectable:
-                print('\t{} is within detection angle! Cos = {}'.format(marker, cos_sim))
+                print('\t{} is within detection angle! Cos = {}'.format(
+                    marker, cos_sim))
                 self._publish_marker_detection(self.marked_positions[marker],
                                                cos_sim)
 
@@ -175,7 +176,7 @@ class sim_sss_detector:
     def _construct_pose_stamped_from_marker_msg(self, marker):
         marker_pose_stamped = PoseStamped()
         marker_pose_stamped.pose = marker.pose
-        marker_pose_stamped.header.stamp = self.stamp
+        marker_pose_stamped.header.stamp = rospy.Time()
         marker_pose_stamped.header.frame_id = marker.header.frame_id
         return marker_pose_stamped
 
@@ -184,7 +185,7 @@ class sim_sss_detector:
             marker)
         self.tf_listener.waitForTransform(marker_pose_stamped.header.frame_id,
                                           self.frame_id, rospy.Time(),
-                                          rospy.Duration(1.0))
+                                          rospy.Duration(2.0))
         marker_transformed = self.tf_listener.transformPose(
             self.frame_id, marker_pose_stamped)
         return marker_transformed

--- a/sss_object_detection/scripts/sim_sss_detection_publisher.py
+++ b/sss_object_detection/scripts/sim_sss_detection_publisher.py
@@ -26,14 +26,16 @@ class sim_sss_detector:
         self.detection_range = detection_range
         self.buoy_radius = buoy_radius
         self.noise_sigma = noise_sigma
-        self.frame_id = 'utm'
+        self.published_frame_id = '{}/base_link'.format(self.robot_name)
+        self.gt_frame_id = 'gt/{}/base_link'.format(self.robot_name)
         self.current_pose = None
         self.marked_positions = {}
 
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
-        self.odom_sub = rospy.Subscriber('/{}/sim/odom'.format(robot_name),
-                                         Odometry, self._update_pose)
+        self.odom_sub = rospy.Subscriber(
+            '/{}/sim/odom'.format(self.robot_name), Odometry,
+            self._update_pose)
         self.marked_pos_sub = rospy.Subscriber(
             '/{}/sim/marked_positions'.format(robot_name), MarkerArray,
             self._update_marked_positions)
@@ -106,7 +108,7 @@ class sim_sss_detector:
 
         # Wrap ObjectHypothesisWithPose msg into Detection2D msg
         detection_msg = Detection2D()
-        detection_msg.header.frame_id = self.frame_id
+        detection_msg.header.frame_id = self.published_frame_id
         detection_msg.header.stamp = rospy.Time.now()
         detection_msg.results.append(object_hypothesis)
 
@@ -181,7 +183,7 @@ class sim_sss_detector:
 
     def _transform_pose(self, pose, from_frame):
         trans = self._wait_for_transform(from_frame=from_frame,
-                                         to_frame=self.frame_id)
+                                         to_frame=self.gt_frame_id)
         pose_transformed = tf2_geometry_msgs.do_transform_pose(pose, trans)
         return pose_transformed
 

--- a/sss_object_detection/scripts/sim_sss_detection_publisher.py
+++ b/sss_object_detection/scripts/sim_sss_detection_publisher.py
@@ -2,7 +2,8 @@
 
 import rospy
 import numpy as np
-import tf
+import tf2_ros
+import tf2_geometry_msgs
 from nav_msgs.msg import Odometry
 from vision_msgs.msg import ObjectHypothesisWithPose, Detection2DArray, Detection2D
 from visualization_msgs.msg import Marker, MarkerArray
@@ -25,25 +26,23 @@ class sim_sss_detector:
         self.detection_range = detection_range
         self.buoy_radius = buoy_radius
         self.noise_sigma = noise_sigma
-        self.prev_pose = None
+        self.frame_id = 'utm'
         self.current_pose = None
-        self.yaw = None
-        self.frame_id = None
-        self.stamp = rospy.Time.now()
         self.marked_positions = {}
 
-        self.tf_listener = tf.TransformListener()
-        self.odom_sub = rospy.Subscriber('/{}/dr/odom'.format(robot_name),
+        self.tf_buffer = tf2_ros.Buffer()
+        self.tf_listener = tf2_ros.TransformListener(self.tf_buffer)
+        self.odom_sub = rospy.Subscriber('/{}/sim/odom'.format(robot_name),
                                          Odometry, self._update_pose)
         self.marked_pos_sub = rospy.Subscriber(
             '/{}/sim/marked_positions'.format(robot_name), MarkerArray,
             self._update_marked_positions)
         self.pub = rospy.Publisher(
-            '/{}/sim/sidescan/detection_hypothesis'.format(robot_name),
+            '/{}/payload/sidescan/detection_hypothesis'.format(robot_name),
             Detection2DArray,
             queue_size=2)
         self.pub_detected_markers = rospy.Publisher(
-            '/{}/sim/sidescan/detected_markers'.format(robot_name),
+            '/{}/payload/sidescan/detected_markers'.format(robot_name),
             Marker,
             queue_size=2)
 
@@ -58,15 +57,10 @@ class sim_sss_detector:
             len(self.marked_positions)))
 
     def _update_pose(self, msg):
-        """Update prev_pose and current_pose according to the odom msg received"""
-        if not self.prev_pose:
-            self.prev_pose = msg.pose.pose
-            self.current_pose = msg.pose.pose
+        """Update pose based on msg from simulated groundtruth odom at /{robot_name}/sim/odom"""
 
-        self.stamp = msg.header.stamp
-        self.frame_id = msg.header.frame_id
-        self.prev_pose = self.current_pose
-        self.current_pose = msg.pose.pose
+        self.current_pose = self._transform_pose(
+            msg.pose, from_frame=msg.header.frame_id).pose
 
         markers_in_range = self.get_markers_in_detection_range()
         heading = self.calculate_heading()
@@ -76,8 +70,7 @@ class sim_sss_detector:
             detectable = cos_sim <= self.buoy_radius
 
             if detectable:
-                print('\t{} is within detection angle! Cos = {}'.format(
-                    marker, cos_sim))
+                print('Detected {}, cos = {}'.format(marker, cos_sim))
                 self._publish_marker_detection(self.marked_positions[marker],
                                                cos_sim)
 
@@ -92,7 +85,8 @@ class sim_sss_detector:
         object_hypothesis.score = (-cos_sim + (self.buoy_radius * 2)) / (
             self.buoy_radius * 2)
 
-        marker_transformed = self._wait_for_marker_transform(marker)
+        marker_transformed = self._transform_pose(
+            marker, from_frame=marker.header.frame_id)
         object_hypothesis.pose.pose = marker_transformed.pose
         # Add random noise to pose of object
         object_hypothesis.pose.pose.position.x += np.random.randn(
@@ -173,26 +167,28 @@ class sim_sss_detector:
                 position_array=vec_to_position)
         return vec_to_position
 
-    def _construct_pose_stamped_from_marker_msg(self, marker):
-        marker_pose_stamped = PoseStamped()
-        marker_pose_stamped.pose = marker.pose
-        marker_pose_stamped.header.stamp = rospy.Time()
-        marker_pose_stamped.header.frame_id = marker.header.frame_id
-        return marker_pose_stamped
+    def _wait_for_transform(self, from_frame, to_frame):
+        """Wait for transform from from_frame to to_frame"""
+        trans = None
+        while trans is None:
+            try:
+                trans = self.tf_buffer.lookup_transform(
+                    to_frame, from_frame, rospy.Time())
+            except (tf2_ros.LookupException, tf2_ros.ConnectivityException,
+                    tf2_ros.ExtrapolationException) as error:
+                print('Failed to transform. Error: {}'.format(error))
+        return trans
 
-    def _wait_for_marker_transform(self, marker):
-        marker_pose_stamped = self._construct_pose_stamped_from_marker_msg(
-            marker)
-        self.tf_listener.waitForTransform(marker_pose_stamped.header.frame_id,
-                                          self.frame_id, rospy.Time(),
-                                          rospy.Duration(2.0))
-        marker_transformed = self.tf_listener.transformPose(
-            self.frame_id, marker_pose_stamped)
-        return marker_transformed
+    def _transform_pose(self, pose, from_frame):
+        trans = self._wait_for_transform(from_frame=from_frame,
+                                         to_frame=self.frame_id)
+        pose_transformed = tf2_geometry_msgs.do_transform_pose(pose, trans)
+        return pose_transformed
 
     def _get_distance_to_marker(self, marker):
         """Return distance from the marker to current_pose"""
-        marker_transformed = self._wait_for_marker_transform(marker)
+        marker_transformed = self._transform_pose(marker,
+                                                  marker.header.frame_id)
 
         distance = self._calculate_distance_to_position(
             marker_transformed.pose.position)
@@ -213,8 +209,9 @@ class sim_sss_detector:
         Used to determine whether the marker is observable:
         A marker is observable if the magnitude of the projection of the vector
         from self.current_pose.position onto the heading vector <= the marker's radius."""
-        marker_transformed = self._wait_for_marker_transform(
-            self.marked_positions[marker])
+        pose = self.marked_positions[marker]
+        marker_transformed = self._transform_pose(
+            pose, from_frame=pose.header.frame_id)
 
         vec_to_marker_position = self._get_vec_to_position(
             marker_transformed.pose.position, normalized=True)


### PR DESCRIPTION
- compute simulated buoy detection using the groundtruth pose published at `/{vehicle}/sim/odom` instead of the deadreckoning odom at `/{vehicle}/dr/odom`
- to make simulated and real detection more consistent, transform and publish simulated detection in `/{vehicle}/base_link`
- update topic names
- use tf2 packages instead of tf packages